### PR TITLE
aws-vpc: associate module route tables to subnets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Terraform validate & format 
         run: |
           # terraform validate
-          terraform fmt -check
+          terraform fmt -check -recursive -diff
 
       - name: tflint
         run: |

--- a/modules/public-infra/route_tables.tf
+++ b/modules/public-infra/route_tables.tf
@@ -6,6 +6,13 @@ resource "aws_route_table" "public" {
   tags = merge(var.tags, { Name = "${var.derived_prefix}-public-rtb" })
 }
 
+resource "aws_route_table_association" "public" {
+  for_each = aws_subnet.public
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public[0].id
+}
+
 resource "aws_route" "igw" {
   count = var.mode != "public" ? 0 : 1
 

--- a/route_tables.tf
+++ b/route_tables.tf
@@ -8,6 +8,13 @@ resource "aws_route_table" "private" {
   })
 }
 
+resource "aws_route_table_association" "private" {
+  for_each = aws_subnet.private
+
+  subnet_id      = each.value.id
+  route_table_id = !var.private_subnets_only && var.nat_gateway_setup == "ha" ? aws_route_table.private[each.key].id : aws_route_table.private["private"].id
+}
+
 resource "aws_route" "nat" {
   for_each = var.private_subnets_only ? {} : aws_route_table.private
 


### PR DESCRIPTION
Route tables for private & public subnets created in the module are not associated with the subnets, default VPC route table is still used.