### PR TITLE
aws-vpc: update aws provider minimum version to v5.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,12 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: test/go.mod
-      - uses: hashicorp/setup-terraform@v2
-      - uses: terraform-linters/setup-tflint@v1
+      - uses: hashicorp/setup-terraform@v3
+      - uses: terraform-linters/setup-tflint@v4
 
       - name: Terraform validate & format 
         run: |
@@ -24,7 +24,7 @@ jobs:
 
       - name: tflint
         run: |
-          tflint .
+          tflint
 
       - name: tfsec
         run: |

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/config.tf
+++ b/config.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/module-test/provider.tf
+++ b/module-test/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 5.0"
     }
   }
 

--- a/modules/public-infra/nat_gateways.tf
+++ b/modules/public-infra/nat_gateways.tf
@@ -3,7 +3,7 @@ resource "aws_eip" "nat" {
 
   for_each = toset(local.nat_gateway_azs)
 
-  vpc = true
+  domain = "vpc"
 
   tags = merge(var.tags, { Name = "${var.vpc.name}-nat-eip-${each.value}" })
 }

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/vtstanescu/aws-vpc
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gruntwork-io/terratest v0.40.10

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,3 +1,4 @@
+#tfsec:ignore:aws-ec2-require-vpc-flow-logs-for-all-vpcs
 resource "aws_vpc" "vpc" {
   cidr_block = var.main_cidr_block
 


### PR DESCRIPTION
* replace vpc attribute with domain for aws_eip resource.